### PR TITLE
Add Resfinder 4 parsing for the ResFinder_results_tab.txt output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 *.egg-info
 *.pyc
+build
+dist

--- a/hAMRonization/AbricateIO.py
+++ b/hAMRonization/AbricateIO.py
@@ -5,7 +5,7 @@ from .Interfaces import hAMRonizedResultIterator
 
 required_metadata = ['analysis_software_version',
                      'reference_database_version']
-
+optional_metadata = []
 
 class AbricateIterator(hAMRonizedResultIterator):
 

--- a/hAMRonization/AmrFinderPlusIO.py
+++ b/hAMRonization/AmrFinderPlusIO.py
@@ -7,7 +7,7 @@ from .Interfaces import hAMRonizedResultIterator
 required_metadata = ['analysis_software_version',
                      'reference_database_version',
                      'input_file_name']
-
+optional_metadata = []
 
 class AmrFinderPlusIterator(hAMRonizedResultIterator):
 

--- a/hAMRonization/AmrPlusPlusIO.py
+++ b/hAMRonization/AmrPlusPlusIO.py
@@ -7,7 +7,7 @@ from .Interfaces import hAMRonizedResultIterator
 required_metadata = ['analysis_software_version',
                      'reference_database_version',
                      'input_file_name']
-
+optional_metadata = []
 
 class AmrPlusPlusIterator(hAMRonizedResultIterator):
 

--- a/hAMRonization/AribaIO.py
+++ b/hAMRonization/AribaIO.py
@@ -7,7 +7,7 @@ required_metadata = ['analysis_software_version',
                      'reference_database_version',
                      'reference_database_id',
                      'input_file_name']
-
+optional_metadata = []
 
 class AribaIterator(hAMRonizedResultIterator):
 

--- a/hAMRonization/CSStarIO.py
+++ b/hAMRonization/CSStarIO.py
@@ -9,7 +9,7 @@ required_metadata = ['analysis_software_version',
                      'reference_database_version',
                      'input_file_name',
                      'reference_database_id']
-
+optional_metadata = []
 
 class CSStarIterator(hAMRonizedResultIterator):
 

--- a/hAMRonization/DeepArgIO.py
+++ b/hAMRonization/DeepArgIO.py
@@ -6,7 +6,7 @@ from .Interfaces import hAMRonizedResultIterator
 required_metadata = ['analysis_software_version',
                      'reference_database_version',
                      'input_file_name']
-
+optional_metadata = []
 
 class DeepArgIterator(hAMRonizedResultIterator):
 

--- a/hAMRonization/GrootIO.py
+++ b/hAMRonization/GrootIO.py
@@ -8,7 +8,7 @@ required_metadata = ['analysis_software_version',
                      'reference_database_id',
                      'reference_database_version',
                      'input_file_name']
-
+optional_metadata = []
 
 class GrootIterator(hAMRonizedResultIterator):
 

--- a/hAMRonization/Interfaces.py
+++ b/hAMRonization/Interfaces.py
@@ -265,8 +265,14 @@ def generic_cli_interface():
     if args.analysis_tool and args.analysis_tool != 'summarize':
         required_mandatory_metadata = \
                 hAMRonization._RequiredToolMetadata[args.analysis_tool]
+        optional_metadata = \
+                hAMRonization._OptionalToolMetadata[args.analysis_tool]
+        
+        metadata_fields = required_mandatory_metadata
+        metadata_fields.extend(optional_metadata)
+
         metadata = {field: getattr(args, field)
-                    for field in required_mandatory_metadata}
+                    for field in metadata_fields}
 
         # parse reports and write as appropriate (only first report with head
         # in tsv mode)

--- a/hAMRonization/Interfaces.py
+++ b/hAMRonization/Interfaces.py
@@ -199,6 +199,13 @@ def generate_tool_subparser(subparser, analysis_tool):
         tool_parser.add_argument(f"--{field}", required=True,
                                  help=f"Input string containing the {field} "
                                  f"for {analysis_tool}")
+    # any missing optional fields need supplied as CLI argument
+    optional_metadata = \
+        hAMRonization._OptionalToolMetadata[analysis_tool]
+    for field in optional_metadata:
+        tool_parser.add_argument(f"--{field}",
+                                 help=f"Input string containing the {field} "
+                                 f"for {analysis_tool}")
     return subparser
 
 

--- a/hAMRonization/KmerResistanceIO.py
+++ b/hAMRonization/KmerResistanceIO.py
@@ -6,7 +6,7 @@ from .Interfaces import hAMRonizedResultIterator
 required_metadata = ['analysis_software_version',
                      'reference_database_version',
                      'input_file_name']
-
+optional_metadata = []
 
 class KmerResistanceIterator(hAMRonizedResultIterator):
 

--- a/hAMRonization/ResFamsIO.py
+++ b/hAMRonization/ResFamsIO.py
@@ -6,7 +6,7 @@ from .Interfaces import hAMRonizedResultIterator
 required_metadata = ['analysis_software_version',
                      'reference_database_version',
                      'input_file_name']
-
+optional_metadata = []
 
 class ResFamsIterator(hAMRonizedResultIterator):
 

--- a/hAMRonization/ResFinderIO.py
+++ b/hAMRonization/ResFinderIO.py
@@ -82,6 +82,7 @@ class ResFinderIterator(hAMRonizedResultIterator):
                                     "results"][drug_class][
                                         drug_class.lower()][
                                             gene_name][field]
+                                    if _start > _stop:
 
                 yield self.hAMRonize(result, self.metadata)
                 result = {}

--- a/hAMRonization/ResFinderIO.py
+++ b/hAMRonization/ResFinderIO.py
@@ -47,7 +47,7 @@ class ResFinderIterator(hAMRonizedResultIterator):
             'Resistance gene': 'gene_symbol',
             'Identity': 'sequence_identity',
             'HSP_length': None,
-            'Alignment Length/Gene Length': 'reference_gene_length',
+            'Alignment Length/Gene Length': None,
             'Position in reference': None,
             'Contig': 'input_sequence_id',
             'Position in contig': None,
@@ -60,6 +60,10 @@ class ResFinderIterator(hAMRonizedResultIterator):
             '_stop': 'input_gene_stop',
             # infered from Position in contig field
             '_strand': 'strand_orientation',
+            # Resistance gene is mapped to both symbol and name
+            '_gene_name': 'gene_name',
+            # decomposed from Alignment Length/Gene Length e.g 1176/1176
+            '_reference_gene_length': 'reference_gene_length'
         }
         self.metadata = metadata
 
@@ -114,6 +118,7 @@ class ResFinderIterator(hAMRonizedResultIterator):
         elif self.metadata['analysis_software_name'] == 'resfinder 4':
             reader = csv.DictReader(handle, delimiter='\t')
             for result in reader:
+                result['_gene_name'] = result['Resistance gene']
                 _start, _stop = result['Position in contig'].split('..')
                 if _start > _stop:
                     _strand = "-"
@@ -122,4 +127,8 @@ class ResFinderIterator(hAMRonizedResultIterator):
                 result['_start'] = _start
                 result['_stop']  = _stop
                 result["_strand"] = _strand
+                _reference_gene_length = result['Alignment Length/Gene Length'].split("/")[0]
+                result['_reference_gene_length'] = _reference_gene_length
+                yield self.hAMRonize(result, self.metadata)
+                result = {}
     

--- a/hAMRonization/ResFinderIO.py
+++ b/hAMRonization/ResFinderIO.py
@@ -6,6 +6,7 @@ from .Interfaces import hAMRonizedResultIterator
 required_metadata = ['analysis_software_version',
                      'reference_database_version']
 
+optional_metadata = ['input_file_name']
 
 class ResFinderIterator(hAMRonizedResultIterator):
 

--- a/hAMRonization/ResFinderIO.py
+++ b/hAMRonization/ResFinderIO.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import json
+import csv
 from .Interfaces import hAMRonizedResultIterator
 
 required_metadata = ['analysis_software_version',
@@ -11,11 +12,13 @@ optional_metadata = ['input_file_name']
 class ResFinderIterator(hAMRonizedResultIterator):
 
     def __init__(self, source, metadata):
-        metadata['analysis_software_name'] = 'resfinder.py'
         metadata['reference_database_id'] = 'resfinder'
-        self.metadata = metadata
 
-        self.field_mapping = {
+        try:
+            with open(source) as fh:
+                json.load(fh) # test if version 3 json
+            metadata['analysis_software_name'] = 'resfinder 3'
+            self.field_mapping = {
             'resistance_gene': 'gene_symbol',
             'identity': 'sequence_identity',
             'HSP_length': None,
@@ -38,6 +41,28 @@ class ResFinderIterator(hAMRonizedResultIterator):
             # parsed from top level of within class results
             '_gene_name': 'gene_name'
         }
+        except(ValueError): # Resfinder 4 tsv file
+            metadata['analysis_software_name'] = 'resfinder 4'
+            self.field_mapping = {
+            'Resistance gene': 'gene_symbol',
+            'Identity': 'sequence_identity',
+            'HSP_length': None,
+            'Alignment Length/Gene Length': 'reference_gene_length',
+            'Position in reference': None,
+            'Contig': 'input_sequence_id',
+            'Position in contig': None,
+            'Accession no.': 'reference_accession',
+            'Phenotype': 'drug_class',
+            'Coverage': 'coverage_percentage',
+            'hit_id': None,
+            # decomposed from Position in contig e.g "10432..11277"
+            '_start': 'input_gene_start',
+            '_stop': 'input_gene_stop',
+            # infered from Position in contig field
+            '_strand': 'strand_orientation',
+        }
+        self.metadata = metadata
+
         super().__init__(source, self.field_mapping, self.metadata)
 
     def parse(self, handle):
@@ -45,45 +70,56 @@ class ResFinderIterator(hAMRonizedResultIterator):
         Read each and return it
         """
         # skip any manually specified fields for later
+        if self.metadata['analysis_software_name'] == 'resfinder 3':
+            report = json.load(handle)
+            result = {}
+            for drug_class in report["resfinder"]["results"]:
+                hit_status = report["resfinder"]["results"][drug_class][
+                                    drug_class.lower()]
 
-        report = json.load(handle)
-        result = {}
-        for drug_class in report["resfinder"]["results"]:
-            hit_status = report["resfinder"]["results"][drug_class][
+                if hit_status != 'No hit found':
+
+                    gene_names = report["resfinder"]["results"][drug_class][
                                 drug_class.lower()]
+                    for gene_name in gene_names:
+                        for field in (report["resfinder"]["results"][drug_class][
+                                    drug_class.lower()][gene_name]):
+                            # add input_file_name from user_input
+                            result['_gene_name'] = gene_name
+                            result['_input_file_name'] = report['resfinder'][
+                                'user_input']['filename(s)'][0]
 
-            if hit_status != 'No hit found':
-
-                gene_names = report["resfinder"]["results"][drug_class][
-                             drug_class.lower()]
-                for gene_name in gene_names:
-                    for field in (report["resfinder"]["results"][drug_class][
-                                  drug_class.lower()][gene_name]):
-                        # add input_file_name from user_input
-                        result['_gene_name'] = gene_name
-                        result['_input_file_name'] = report['resfinder'][
-                            'user_input']['filename(s)'][0]
-
-                        if field in self.field_mapping:
-                            if field == 'positions_in_contig':
-                                # decompose to get start and stop
-                                coordinates = report["resfinder"]["results"][
-                                    drug_class][drug_class.lower()][
-                                        gene_name][field].split("..")
-                                _start = int(coordinates[0])
-                                _stop = int(coordinates[1])
-                                _strand = "+"
-                                if _start < _stop:
-                                    _strand = "-"
-                                result["_start"] = _start
-                                result["_stop"] = _stop
-                                result["_strand"] = _strand
-                            else:
-                                result[field] = report["resfinder"][
-                                    "results"][drug_class][
-                                        drug_class.lower()][
-                                            gene_name][field]
+                            if field in self.field_mapping:
+                                if field == 'positions_in_contig':
+                                    # decompose to get start and stop
+                                    coordinates = report["resfinder"]["results"][
+                                        drug_class][drug_class.lower()][
+                                            gene_name][field].split("..")
+                                    _start = int(coordinates[0])
+                                    _stop = int(coordinates[1])
+                                    _strand = "+"
                                     if _start > _stop:
+                                        _strand = "-"
+                                    result["_start"] = _start
+                                    result["_stop"] = _stop
+                                    result["_strand"] = _strand
+                                else:
+                                    result[field] = report["resfinder"][
+                                        "results"][drug_class][
+                                            drug_class.lower()][
+                                                gene_name][field]
 
-                yield self.hAMRonize(result, self.metadata)
-                result = {}
+                    yield self.hAMRonize(result, self.metadata)
+                    result = {}
+        elif self.metadata['analysis_software_name'] == 'resfinder 4':
+            reader = csv.DictReader(handle, delimiter='\t')
+            for result in reader:
+                _start, _stop = result['Position in contig'].split('..')
+                if _start > _stop:
+                    _strand = "-"
+                else:
+                    _strand = "+"
+                result['_start'] = _start
+                result['_stop']  = _stop
+                result["_strand"] = _strand
+    

--- a/hAMRonization/RgiIO.py
+++ b/hAMRonization/RgiIO.py
@@ -8,7 +8,7 @@ from .Interfaces import hAMRonizedResultIterator
 required_metadata = ['analysis_software_version',
                      'reference_database_version',
                      'input_file_name']
-
+optional_metadata = []
 
 class RgiIterator(hAMRonizedResultIterator):
 

--- a/hAMRonization/SraxIO.py
+++ b/hAMRonization/SraxIO.py
@@ -7,7 +7,7 @@ required_metadata = ['analysis_software_version',
                      'reference_database_version',
                      'reference_database_id',
                      'input_file_name']
-
+optional_metadata = []
 
 class SraxIterator(hAMRonizedResultIterator):
 

--- a/hAMRonization/Srst2IO.py
+++ b/hAMRonization/Srst2IO.py
@@ -6,7 +6,7 @@ from .Interfaces import hAMRonizedResultIterator
 required_metadata = ['analysis_software_version',
                      'reference_database_version',
                      'input_file_name']
-
+optional_metadata = []
 
 class Srst2Iterator(hAMRonizedResultIterator):
 

--- a/hAMRonization/StarAmrIO.py
+++ b/hAMRonization/StarAmrIO.py
@@ -5,7 +5,7 @@ from .Interfaces import hAMRonizedResultIterator
 
 required_metadata = ['analysis_software_version',
                      'reference_database_version']
-
+optional_metadata = []
 
 class StarAmrIterator(hAMRonizedResultIterator):
 

--- a/hAMRonization/__init__.py
+++ b/hAMRonization/__init__.py
@@ -70,6 +70,22 @@ _RequiredToolMetadata = {
     "groot": GrootIO.required_metadata,
 }
 
+_OptionalToolMetadata = {
+    "abricate": AbricateIO.optional_metadata,
+    "amrfinderplus": AmrFinderPlusIO.optional_metadata,
+    "ariba": AribaIO.optional_metadata,
+    "rgi": RgiIO.optional_metadata,
+    "resfinder": ResFinderIO.optional_metadata,
+    "srax": SraxIO.optional_metadata,
+    "deeparg": DeepArgIO.optional_metadata,
+    "kmerresistance": KmerResistanceIO.optional_metadata,
+    "srst2": Srst2IO.optional_metadata,
+    "staramr": StarAmrIO.optional_metadata,
+    "csstar": CSStarIO.optional_metadata,
+    "amrplusplus": AmrPlusPlusIO.optional_metadata,
+    "resfams": ResFamsIO.optional_metadata,
+    "groot": GrootIO.optional_metadata,
+}
 
 def parse(handle, metadata, tool):
     r"""Turn a sequence file into an iterator returning SeqRecords.

--- a/test/data/raw_outputs/resfinder/ResFinder4_results_tab.txt
+++ b/test/data/raw_outputs/resfinder/ResFinder4_results_tab.txt
@@ -1,0 +1,17 @@
+Resistance gene	Identity	Alignment Length/Gene Length	Coverage	Position in reference	Contig	Position in contig	Phenotype	Accession no.
+rmtC	100.00	846/846	100.0	1..846	NODE_14_length_98505_cov_19.634799	10432..11277	Aminoglycoside resistance	AB194779
+aac(3)-IIa	99.77	861/861	100.0	1..861	NODE_27_length_2798_cov_14.473509	143..1003	Aminoglycoside resistance	X51534
+aac(6')-Ib-cr	100.00	600/600	100.0	1..600	NODE_30_length_2382_cov_14.597898	1640..2239	Fluoroquinolone and aminoglycoside resistance	DQ303918
+blaOKP-B-15	99.42	860/861	99.88385598141696	1..860	NODE_9_length_261278_cov_7.764227	178633..179492	Beta-lactam resistance	AM850917
+blaOKP-B-2	99.30	861/861	100.0	1..861	NODE_9_length_261278_cov_7.764227	178633..179493	Beta-lactam resistance	AM051151
+blaNDM-1	100.00	813/813	100.0	1..813	NODE_14_length_98505_cov_19.634799	11835..12647	Beta-lactam resistance	FN396876
+blaOXA-1	100.00	831/831	100.0	1..831	NODE_30_length_2382_cov_14.597898	679..1509	Beta-lactam resistance	HQ170510
+fosA	92.86	420/420	100.0	1..420	NODE_6_length_370679_cov_11.470840	347102..347521	Fosfomycin resistance	ACZD01000244
+fosA	92.86	420/420	100.0	1..420	NODE_6_length_370679_cov_11.470840	347102..347521	Fosfomycin resistance	ACWO01000079
+oqxB	95.59	3153/3153	100.0	1..3153	NODE_2_length_744173_cov_11.475942	45335..48487	Quinolone resistance	EU370913
+oqxA	93.88	1176/1176	100.0	1..1176	NODE_2_length_744173_cov_11.475942	44136..45311	Quinolone resistance	EU370913
+qnrB1	100.00	645/645	100.0	1..645	NODE_12_length_120343_cov_13.933826	917..1561	Quinolone resistance	DQ351241
+aac(6')-Ib-cr	100.00	600/600	100.0	1..600	NODE_30_length_2382_cov_14.597898	1640..2239	Fluoroquinolone and aminoglycoside resistance	DQ303918
+sul1	99.88	840/840	100.0	1..840	NODE_14_length_98505_cov_19.634799	3268..4107	Sulphonamide resistance	X15024
+sul1	99.88	840/840	100.0	1..840	NODE_14_length_98505_cov_19.634799	3268..4107	Sulphonamide resistance	JF262165
+dfrA14	100.00	474/474	100.0	1..474	NODE_21_length_8231_cov_13.939252	1750..2223	Trimethoprim resistance	KF921535

--- a/test/dummy/resfinder/ResFinder4_results_tab.txt
+++ b/test/dummy/resfinder/ResFinder4_results_tab.txt
@@ -1,2 +1,2 @@
 Resistance gene	Identity	Alignment Length/Gene Length	Coverage	Position in reference	Contig	Position in contig	Phenotype	Accession no.
-oqxA	99.58	1176/1176	100.0	1..1176	NZ_LR792628.1 Klebsiella pneumoniae isolate SB5881 chromosome SB5881_omosome	10432..11277	Quinolone resistance	EU370913
+oqxA	99.58	1176/1176	100.0	1..1176	NZ_LR792628.1 Klebsiella pneumoniae isolate SB5881 chromosome SB5881_omosome	1333608..1334783	Quinolone resistance	EU370913

--- a/test/dummy/resfinder/ResFinder4_results_tab.txt
+++ b/test/dummy/resfinder/ResFinder4_results_tab.txt
@@ -1,0 +1,2 @@
+Resistance gene	Identity	Alignment Length/Gene Length	Coverage	Position in reference	Contig	Position in contig	Phenotype	Accession no.
+oqxA	99.58	1176/1176	100.0	1..1176	NZ_LR792628.1 Klebsiella pneumoniae isolate SB5881 chromosome SB5881_omosome	10432..11277	Quinolone resistance	EU370913

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -20,8 +20,11 @@ hamronize rgi --input_file_name rgi_bwt_report --analysis_software_version rgi_b
 # test multi-report usage
 hamronize rgi --input_file_name rgi_report --analysis_software_version rgi_v1 --reference_database_version card_v1 data/raw_outputs/rgi/rgi.txt data/raw_outputs/rgibwt/Kp11_bwtoutput.gene_mapping_data.txt --output hamronized_rgi_and_rgibwt.tsv
 
-hamronize resfinder --analysis_software_version resfinder_v1 --reference_database_version resfinder_db_v1 data/raw_outputs/resfinder/data_resfinder.json --format json --output hamronized_resfinder.json
-hamronize resfinder --analysis_software_version resfinder_v1 --reference_database_version resfinder_db_v1 data/raw_outputs/resfinder/data_resfinder.json --format tsv --output hamronized_resfinder.tsv
+hamronize resfinder --analysis_software_version resfinder_v1 --reference_database_version resfinder_db_v1 data/raw_outputs/resfinder/data_resfinder.json --format json --output hamronized_resfinder3.json
+hamronize resfinder --analysis_software_version resfinder_v1 --reference_database_version resfinder_db_v1 data/raw_outputs/resfinder/data_resfinder.json --format tsv --output hamronized_resfinder3.tsv
+hamronize resfinder --input_file_name resfinder4_report --analysis_software_version resfinder_v1 --reference_database_version resfinder_db_v1 data/raw_outputs/resfinder/ResFinder4_results_tab.txt --format json --output hamronized_resfinder4.json
+hamronize resfinder --input_file_name resfinder4_report --analysis_software_version resfinder_v1 --reference_database_version resfinder_db_v1 data/raw_outputs/resfinder/ResFinder4_results_tab.txt --format tsv --output hamronized_resfinder4.tsv
+
 
 hamronize srax --reference_database_id srax_default --input_file_name srax_report --reference_database_version srax_db_v1 --analysis_software_version srax_v1 --format json data/raw_outputs/srax/sraX_detected_ARGs.tsv --output hamronized_srax.json
 hamronize srax --reference_database_id srax_default --input_file_name srax_report --reference_database_version srax_db_v1 --analysis_software_version srax_v1 --format tsv data/raw_outputs/srax/sraX_detected_ARGs.tsv --output hamronized_srax.tsv

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -220,7 +220,7 @@ def test_kmerresistance():
         assert result.reference_gene_stop is None
 
 
-def test_resfinder():
+def test_resfinder3():
     metadata = {"analysis_software_version": "0.0.1", "reference_database_version": "2019-Jul-28"}
     parsed_report = hAMRonization.parse("dummy/resfinder/data_resfinder.json", metadata, "resfinder")
 
@@ -232,14 +232,14 @@ def test_resfinder():
         assert result.reference_database_id == 'resfinder'
         assert result.reference_database_version == '2019-Jul-28'
         assert result.reference_accession == 'EU370913'
-        assert result.analysis_software_name == 'resfinder.py'  # drop the .py?
+        assert result.analysis_software_name == 'resfinder 3'  # drop the .py?
         assert result.analysis_software_version == '0.0.1'
 
         # optional fields - present in dummy dataset
         assert result.input_sequence_id == 'NZ_LR792628.1 Klebsiella pneumoniae isolate SB5881 chromosome SB5881_omosome'
         assert result.input_gene_start == 1333608
         assert result.input_gene_stop == 1334783
-        assert result.strand_orientation == '-'
+        assert result.strand_orientation == '+'
         assert result.drug_class == 'Quinolone resistance'
         assert result.sequence_identity == 99.57
         assert result.reference_gene_length == 1176
@@ -260,6 +260,45 @@ def test_resfinder():
         assert result.reference_gene_start is None
         assert result.reference_gene_stop is None
 
+def test_resfinder4():
+    metadata = {"analysis_software_version": "0.0.1", "reference_database_version": "2019-Jul-28"}
+    parsed_report = hAMRonization.parse("dummy/resfinder/ResFinder4_results_tab.txt", metadata, "resfinder")
+
+    for result in parsed_report:
+        # assert mandatory fields
+        assert result.input_file_name == 'Dummy'
+        assert result.gene_symbol == 'oqxA'
+        assert result.reference_database_id == 'resfinder'
+        assert result.reference_database_version == '2019-Jul-28'
+        assert result.reference_accession == 'EU370913'
+        assert result.analysis_software_name == 'resfinder 4'  # drop the .py?
+        assert result.analysis_software_version == '0.0.1'
+
+        # optional fields - present in dummy dataset
+        assert result.input_sequence_id == 'NZ_LR792628.1 Klebsiella pneumoniae isolate SB5881 chromosome SB5881_omosome'
+        assert result.input_gene_start == 1333608
+        assert result.input_gene_stop == 1334783
+        assert result.strand_orientation == '+'
+        assert result.drug_class == 'Quinolone resistance'
+        assert result.sequence_identity == 99.57
+        assert result.reference_gene_length == 1176
+        assert result.coverage_depth is None
+        assert result.coverage_percentage == 100
+
+        # missing data in report
+        assert result.gene_name is None
+        assert result.input_gene_length is None
+        assert result.antimicrobial_agent is None
+        assert result.reference_protein_length is None
+        assert result.coverage_ratio is None
+        assert result.input_protein_length is None
+        assert result.resistance_mechanism is None
+        assert result.input_protein_start is None
+        assert result.input_protein_stop is None
+        assert result.reference_protein_start is None
+        assert result.reference_protein_stop is None
+        assert result.reference_gene_start is None
+        assert result.reference_gene_stop is None
 
 def test_rgi():
     metadata = {"analysis_software_version": "5.1.0", "reference_database_version": "2019-Jul-28",

--- a/test/test_sanity.py
+++ b/test/test_sanity.py
@@ -261,13 +261,14 @@ def test_resfinder3():
         assert result.reference_gene_stop is None
 
 def test_resfinder4():
-    metadata = {"analysis_software_version": "0.0.1", "reference_database_version": "2019-Jul-28"}
+    metadata = {"analysis_software_version": "0.0.1", "reference_database_version": "2019-Jul-28", "input_file_name": "Dummy"}
     parsed_report = hAMRonization.parse("dummy/resfinder/ResFinder4_results_tab.txt", metadata, "resfinder")
 
     for result in parsed_report:
         # assert mandatory fields
         assert result.input_file_name == 'Dummy'
         assert result.gene_symbol == 'oqxA'
+        assert result.gene_name == 'oqxA'
         assert result.reference_database_id == 'resfinder'
         assert result.reference_database_version == '2019-Jul-28'
         assert result.reference_accession == 'EU370913'
@@ -280,13 +281,12 @@ def test_resfinder4():
         assert result.input_gene_stop == 1334783
         assert result.strand_orientation == '+'
         assert result.drug_class == 'Quinolone resistance'
-        assert result.sequence_identity == 99.57
+        assert result.sequence_identity == 99.58
         assert result.reference_gene_length == 1176
         assert result.coverage_depth is None
         assert result.coverage_percentage == 100
 
         # missing data in report
-        assert result.gene_name is None
         assert result.input_gene_length is None
         assert result.antimicrobial_agent is None
         assert result.reference_protein_length is None


### PR DESCRIPTION
Add Resfinder 4 parsing for the `ResFinder_results_tab.txt` output

It seems ugly to have the optional_metadata added, especially since the line `optional_metadata = []` is added to most parser subclasses. I couldn't find a way to add that as an attribute with default as an empty list.

Added test of a real file to the `run_test.sh` script