### PR TITLE
Bump version to be in line latest release

### DIFF
--- a/hAMRonization/__init__.py
+++ b/hAMRonization/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 from hAMRonization import AbricateIO
 from hAMRonization import AmrFinderPlusIO


### PR DESCRIPTION
I'm not sure of the development structure here (if your master is equivalent to `dev`, and releaeses are stable - or not), but this would at least make sure things are 'equivalent'. Happy to push to 1.0.5 if master is meant to be `dev` vs. 1.0.4 being equal to `master`.

Partly address #78 